### PR TITLE
Add roundup and transfers

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "db:generate": "prisma generate",
     "db:push": "prisma db push",
     "db:migrate": "prisma migrate dev",
+    "db:migrate:deploy": "prisma migrate deploy",
     "backfill:encryption": "npx tsx scripts/backfill-encryption.ts"
   },
   "dependencies": {

--- a/prisma/migrations/20260328120000_roundup_and_transfers/migration.sql
+++ b/prisma/migrations/20260328120000_roundup_and_transfers/migration.sql
@@ -1,0 +1,16 @@
+-- AlterTable
+ALTER TABLE `users` ADD COLUMN `roundupSavingsAccountId` VARCHAR(191) NULL;
+
+-- AlterTable
+ALTER TABLE `accounts` ADD COLUMN `roundUpOnExpenditure` BOOLEAN NOT NULL DEFAULT false;
+ALTER TABLE `accounts` ADD COLUMN `doesRoundupSave` BOOLEAN NOT NULL DEFAULT false;
+
+-- AlterTable
+ALTER TABLE `account_transactions` ADD COLUMN `transferPairId` VARCHAR(191) NULL;
+ALTER TABLE `account_transactions` ADD COLUMN `counterpartyAccountId` VARCHAR(191) NULL;
+
+-- CreateIndex
+CREATE UNIQUE INDEX `users_roundupSavingsAccountId_key` ON `users`(`roundupSavingsAccountId`);
+
+-- AddForeignKey
+ALTER TABLE `users` ADD CONSTRAINT `users_roundupSavingsAccountId_fkey` FOREIGN KEY (`roundupSavingsAccountId`) REFERENCES `accounts`(`id`) ON DELETE SET NULL ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -5,9 +5,12 @@ generator client {
   provider = "prisma-client-js"
 }
 
+// `migrate dev` needs a shadow DB. Hosts like RDS often deny CREATE DATABASE; set SHADOW_DATABASE_URL
+// to a separate empty database on the same server (CREATE DATABASE prisma_shadow; grant your user access).
 datasource db {
-  provider = "mysql"
-  url      = env("DATABASE_URL")
+  provider          = "mysql"
+  url               = env("DATABASE_URL")
+  shadowDatabaseUrl = env("SHADOW_DATABASE_URL")
 }
 
 enum Frequency {
@@ -48,6 +51,8 @@ model User {
   accountTransactions AccountTransaction[]
   mfaCodes            MfaCode[]
   apiKeys             ApiKey[]
+  roundupSavingsAccountId String?  @unique
+  roundupSavingsAccount   Account? @relation("UserRoundupSavings", fields: [roundupSavingsAccountId], references: [id], onDelete: SetNull)
 
   @@map("users")
 }
@@ -141,11 +146,14 @@ model Account {
   institution   String?
   institutionId String?
   balance       Float    @default(0)
-  isMain        Boolean  @default(false)
-  userId        String
-  user          User     @relation(fields: [userId], references: [id], onDelete: Cascade)
-  createdAt     DateTime @default(now())
-  updatedAt     DateTime @updatedAt
+  isMain                 Boolean  @default(false)
+  roundUpOnExpenditure   Boolean  @default(false)
+  doesRoundupSave        Boolean  @default(false)
+  userId                 String
+  user                   User     @relation(fields: [userId], references: [id], onDelete: Cascade)
+  createdAt              DateTime @default(now())
+  updatedAt              DateTime @updatedAt
+  userRoundupSavings     User?    @relation("UserRoundupSavings")
 
   transactions        Transaction[]
   accountTransactions AccountTransaction[]
@@ -183,16 +191,18 @@ model Transaction {
 }
 
 model AccountTransaction {
-  id          String   @id @default(uuid())
-  accountId   String
-  account     Account  @relation(fields: [accountId], references: [id], onDelete: Cascade)
-  type        String   // deposit, withdrawal
-  amount      Float
-  description String
-  userId      String
-  user        User     @relation(fields: [userId], references: [id], onDelete: Cascade)
-  createdAt   DateTime @default(now())
-  updatedAt   DateTime @updatedAt
+  id                     String   @id @default(uuid())
+  accountId              String
+  account                Account  @relation(fields: [accountId], references: [id], onDelete: Cascade)
+  type                   String   // deposit, withdrawal, transfer_out, transfer_in
+  amount                 Float
+  description            String
+  transferPairId         String?
+  counterpartyAccountId  String?
+  userId                 String
+  user                   User     @relation(fields: [userId], references: [id], onDelete: Cascade)
+  createdAt              DateTime @default(now())
+  updatedAt              DateTime @updatedAt
 
   @@map("account_transactions")
 }

--- a/src/app/accounts/page.tsx
+++ b/src/app/accounts/page.tsx
@@ -4,9 +4,29 @@ import { useState, useEffect, useCallback } from 'react'
 import { useForm } from 'react-hook-form'
 import { zodResolver } from '@hookform/resolvers/zod'
 import Link from 'next/link'
-import { accountSchema, expenditureSchema, accountTransactionSchema, AccountInput, ExpenditureInput, AccountTransactionInput } from '@/lib/validations'
+import {
+  accountSchema,
+  expenditureSchema,
+  accountTransactionSchema,
+  accountTransferSchema,
+  AccountInput,
+  ExpenditureInput,
+  AccountTransactionInput,
+  AccountTransferInput,
+} from '@/lib/validations'
 import { cn } from '@/lib/utils'
-import { Plus, Edit, Trash2, DollarSign, CreditCard, TrendingDown, Star, ArrowDownCircle, ArrowUpCircle } from 'lucide-react'
+import {
+  Plus,
+  Edit,
+  Trash2,
+  DollarSign,
+  CreditCard,
+  TrendingDown,
+  Star,
+  ArrowDownCircle,
+  ArrowUpCircle,
+  ArrowLeftRight,
+} from 'lucide-react'
 import { Navigation } from '@/components/Navigation'
 import { useUser } from '@/contexts/UserContext'
 
@@ -19,6 +39,8 @@ interface Account {
   institutionId?: string
   balance: number
   isMain: boolean
+  roundUpOnExpenditure?: boolean
+  doesRoundupSave?: boolean
   createdAt: string
   updatedAt: string
   accountTransactions: AccountTransaction[]
@@ -27,9 +49,11 @@ interface Account {
 
 interface AccountTransaction {
   id: string
-  type: 'deposit' | 'withdrawal'
+  type: 'deposit' | 'withdrawal' | 'transfer_out' | 'transfer_in'
   amount: number
   description: string
+  counterpartyAccountId?: string | null
+  transferPairId?: string | null
   createdAt: string
   updatedAt: string
 }
@@ -47,16 +71,25 @@ export default function AccountsPage() {
   const [showAccountForm, setShowAccountForm] = useState(false)
   const [showExpenditureForm, setShowExpenditureForm] = useState(false)
   const [showTransactionForm, setShowTransactionForm] = useState(false)
-  const [transactionAccount, setTransactionAccount] = useState<Account | null>(null)
+  const [showTransferForm, setShowTransferForm] = useState(false)
+  const [transactionTargetAccountId, setTransactionTargetAccountId] = useState('')
   const [transactionType, setTransactionType] = useState<'deposit' | 'withdrawal'>('deposit')
   const [editingAccount, setEditingAccount] = useState<Account | null>(null)
-  const [selectedAccount, setSelectedAccount] = useState<Account | null>(null)
   const [isSubmittingAccount, setIsSubmittingAccount] = useState(false)
   const [isSubmittingTransaction, setIsSubmittingTransaction] = useState(false)
+  const [isSubmittingTransfer, setIsSubmittingTransfer] = useState(false)
   const [categories, setCategories] = useState<BudgetCategory[]>([])
+  const [roundupSelect, setRoundupSelect] = useState('')
+  const [roundupSaving, setRoundupSaving] = useState(false)
 
-  const accountForm = useForm({
+  const accountForm = useForm<AccountInput>({
     resolver: zodResolver(accountSchema),
+    defaultValues: {
+      balance: 0,
+      isMain: false,
+      roundUpOnExpenditure: false,
+      doesRoundupSave: false,
+    },
   })
 
   const expenditureForm = useForm({
@@ -79,6 +112,28 @@ export default function AccountsPage() {
     },
   })
 
+  const transferForm = useForm<AccountTransferInput>({
+    resolver: zodResolver(accountTransferSchema),
+    defaultValues: {
+      fromAccountId: '',
+      toAccountId: '',
+      amount: 0,
+      description: '',
+    },
+  })
+
+  const fetchRoundupSettings = useCallback(async () => {
+    try {
+      const response = await fetch('/api/user/roundup-settings')
+      if (response.ok) {
+        const data = await response.json()
+        setRoundupSelect(data.roundupSavingsAccountId ?? '')
+      }
+    } catch {
+      setRoundupSelect('')
+    }
+  }, [])
+
   const fetchCategories = useCallback(async () => {
     try {
       const response = await fetch('/api/budget-categories')
@@ -97,8 +152,9 @@ export default function AccountsPage() {
     if (user && !userLoading) {
       fetchAccounts()
       fetchCategories()
+      fetchRoundupSettings()
     }
-  }, [user, userLoading, fetchCategories])
+  }, [user, userLoading, fetchCategories, fetchRoundupSettings])
 
   const fetchAccounts = async () => {
     try {
@@ -182,7 +238,6 @@ export default function AccountsPage() {
         fetchAccounts()
         expenditureForm.reset({ title: '', amount: 0, categoryId: '', accountId: '', createdAt: new Date().toISOString().slice(0, 10) })
         setShowExpenditureForm(false)
-        setSelectedAccount(null)
       } else {
         const err = await response.json()
         alert(err.error || 'Failed to create expenditure')
@@ -200,6 +255,8 @@ export default function AccountsPage() {
       type: account.type,
       balance: Number(account.balance),
       isMain: Boolean(account.isMain),
+      roundUpOnExpenditure: Boolean(account.roundUpOnExpenditure),
+      doesRoundupSave: Boolean(account.doesRoundupSave),
     })
     setShowAccountForm(true)
     window.scrollTo({ top: 0, behavior: 'smooth' })
@@ -219,40 +276,65 @@ export default function AccountsPage() {
     }
   }
 
-  const handleAddExpenditure = (account: Account) => {
-    setSelectedAccount(account)
-    expenditureForm.reset({
-      title: '',
-      amount: 0,
-      categoryId: '',
-      accountId: account.id,
-      createdAt: new Date().toISOString().slice(0, 10)
-    })
-    setShowExpenditureForm(true)
-    window.scrollTo({ top: 0, behavior: 'smooth' })
-  }
-
-  const handleDeposit = (account: Account) => {
-    setTransactionAccount(account)
+  const openDeposit = () => {
+    if (accounts.length === 0) {
+      alert('Add an account first.')
+      return
+    }
     setTransactionType('deposit')
+    setTransactionTargetAccountId(accounts[0].id)
     transactionForm.reset({ type: 'deposit', amount: 0, description: '' })
     setShowTransactionForm(true)
     window.scrollTo({ top: 0, behavior: 'smooth' })
   }
 
-  const handleWithdraw = (account: Account) => {
-    setTransactionAccount(account)
+  const openWithdraw = () => {
+    if (accounts.length === 0) {
+      alert('Add an account first.')
+      return
+    }
     setTransactionType('withdrawal')
+    setTransactionTargetAccountId(accounts[0].id)
     transactionForm.reset({ type: 'withdrawal', amount: 0, description: '' })
     setShowTransactionForm(true)
     window.scrollTo({ top: 0, behavior: 'smooth' })
   }
 
+  const openAddExpenditure = () => {
+    expenditureForm.reset({
+      title: '',
+      amount: 0,
+      categoryId: '',
+      accountId: '',
+      createdAt: new Date().toISOString().slice(0, 10),
+    })
+    setShowExpenditureForm(true)
+    window.scrollTo({ top: 0, behavior: 'smooth' })
+  }
+
+  const openTransfer = () => {
+    if (accounts.length < 2) {
+      alert('You need at least two accounts to transfer.')
+      return
+    }
+    transferForm.reset({
+      fromAccountId: accounts[0].id,
+      toAccountId: accounts[1].id,
+      amount: 0,
+      description: '',
+    })
+    setShowTransferForm(true)
+    window.scrollTo({ top: 0, behavior: 'smooth' })
+  }
+
   const onTransactionSubmit = async (data: AccountTransactionInput) => {
-    if (!transactionAccount) return
+    if (!transactionTargetAccountId) {
+      alert('Choose an account.')
+      return
+    }
     setIsSubmittingTransaction(true)
     try {
-      const response = await fetch(`/api/accounts/${transactionAccount.id}/transactions`, {
+      const response = await fetch(`/api/accounts/${transactionTargetAccountId}/transactions`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ type: transactionType, amount: data.amount, description: data.description }),
@@ -261,7 +343,6 @@ export default function AccountsPage() {
         await fetchAccounts()
         transactionForm.reset({ type: transactionType, amount: 0, description: '' })
         setShowTransactionForm(false)
-        setTransactionAccount(null)
       } else {
         const err = await response.json().catch(() => ({}))
         alert(err?.error ?? 'Failed to create transaction')
@@ -273,6 +354,65 @@ export default function AccountsPage() {
       setIsSubmittingTransaction(false)
     }
   }
+
+  const onTransferSubmit = async (data: AccountTransferInput) => {
+    setIsSubmittingTransfer(true)
+    try {
+      const response = await fetch('/api/account-transfers', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          fromAccountId: data.fromAccountId,
+          toAccountId: data.toAccountId,
+          amount: data.amount,
+          description: data.description?.trim() || undefined,
+        }),
+      })
+      if (response.ok) {
+        await fetchAccounts()
+        transferForm.reset({
+          fromAccountId: accounts[0]?.id ?? '',
+          toAccountId: accounts[1]?.id ?? '',
+          amount: 0,
+          description: '',
+        })
+        setShowTransferForm(false)
+      } else {
+        const err = await response.json().catch(() => ({}))
+        alert(err?.error ?? 'Failed to transfer')
+      }
+    } catch (e) {
+      console.error(e)
+      alert('Failed to transfer. Please try again.')
+    } finally {
+      setIsSubmittingTransfer(false)
+    }
+  }
+
+  const saveRoundupDestination = async () => {
+    setRoundupSaving(true)
+    try {
+      const response = await fetch('/api/user/roundup-settings', {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          roundupSavingsAccountId: roundupSelect === '' ? null : roundupSelect,
+        }),
+      })
+      if (!response.ok) {
+        const err = await response.json().catch(() => ({}))
+        alert(err?.error ?? 'Failed to save round-up settings')
+      }
+    } catch (e) {
+      console.error(e)
+      alert('Failed to save round-up settings.')
+    } finally {
+      setRoundupSaving(false)
+    }
+  }
+
+  const accountNameById = (id: string | null | undefined) =>
+    accounts.find((a) => a.id === id)?.name ?? 'Account'
 
   const expenditureCategories = categories
 
@@ -309,18 +449,102 @@ export default function AccountsPage() {
 
       <main className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
         {/* Page Header */}
-        <div className="flex justify-between items-center mb-6">
-          <h1 className="text-2xl font-bold text-gray-900 dark:text-white">Accounts</h1>
-          <button
-            onClick={() => {
-              setShowAccountForm(true)
-              window.scrollTo({ top: 0, behavior: 'smooth' })
-            }}
-            className="bg-indigo-600 text-white px-4 py-2 rounded-md hover:bg-indigo-700 flex items-center"
-          >
-            <Plus className="h-4 w-4 mr-2" />
-            Add Account
-          </button>
+        <div className="flex flex-col gap-4 mb-6">
+          <div className="flex flex-wrap justify-between items-center gap-3">
+            <h1 className="text-2xl font-bold text-gray-900 dark:text-white">Accounts</h1>
+            <button
+              type="button"
+              onClick={() => {
+                setEditingAccount(null)
+                accountForm.reset({
+                  name: '',
+                  type: 'checking',
+                  balance: 0,
+                  isMain: false,
+                  roundUpOnExpenditure: false,
+                  doesRoundupSave: false,
+                })
+                setShowAccountForm(true)
+                window.scrollTo({ top: 0, behavior: 'smooth' })
+              }}
+              className="bg-indigo-600 text-white px-4 py-2 rounded-md hover:bg-indigo-700 flex items-center"
+            >
+              <Plus className="h-4 w-4 mr-2" />
+              Add Account
+            </button>
+          </div>
+          {accounts.length > 0 && (
+            <div className="flex flex-wrap gap-2">
+              <button
+                type="button"
+                onClick={openDeposit}
+                className="bg-green-600 text-white px-4 py-2 rounded-md hover:bg-green-700 flex items-center text-sm"
+              >
+                <ArrowDownCircle className="h-4 w-4 mr-2" />
+                Deposit
+              </button>
+              <button
+                type="button"
+                onClick={openWithdraw}
+                className="bg-amber-600 text-white px-4 py-2 rounded-md hover:bg-amber-700 flex items-center text-sm"
+              >
+                <ArrowUpCircle className="h-4 w-4 mr-2" />
+                Withdraw
+              </button>
+              <button
+                type="button"
+                onClick={openAddExpenditure}
+                className="border border-gray-300 dark:border-gray-600 text-gray-700 dark:text-gray-300 px-4 py-2 rounded-md hover:bg-gray-50 dark:hover:bg-gray-700 flex items-center text-sm"
+              >
+                <Plus className="h-4 w-4 mr-2" />
+                Add expenditure
+              </button>
+              <button
+                type="button"
+                onClick={openTransfer}
+                className="bg-slate-600 text-white px-4 py-2 rounded-md hover:bg-slate-700 flex items-center text-sm"
+              >
+                <ArrowLeftRight className="h-4 w-4 mr-2" />
+                Transfer
+              </button>
+            </div>
+          )}
+          {accounts.length > 0 && (
+            <div className="bg-white dark:bg-gray-800 rounded-lg shadow p-4 border border-gray-200 dark:border-gray-700">
+              <h2 className="text-sm font-medium text-gray-900 dark:text-white mb-2">Round-up savings destination</h2>
+              <p className="text-xs text-gray-500 dark:text-gray-400 mb-3">
+                When you record spending from an account with “Round up spending” enabled, spare change is moved here (see account settings below).
+              </p>
+              <div className="flex flex-wrap items-end gap-3">
+                <div className="min-w-[200px] flex-1">
+                  <label htmlFor="roundup-destination" className="block text-xs font-medium text-gray-600 dark:text-gray-300 mb-1">
+                    Savings account
+                  </label>
+                  <select
+                    id="roundup-destination"
+                    value={roundupSelect}
+                    onChange={(e) => setRoundupSelect(e.target.value)}
+                    className="block w-full px-3 py-2 border rounded-md text-sm bg-white dark:bg-gray-700 text-gray-900 dark:text-white border-gray-300 dark:border-gray-600"
+                  >
+                    <option value="">None</option>
+                    {accounts.map((acc) => (
+                      <option key={acc.id} value={acc.id}>
+                        {acc.name} ({acc.type})
+                      </option>
+                    ))}
+                  </select>
+                </div>
+                <button
+                  type="button"
+                  onClick={saveRoundupDestination}
+                  disabled={roundupSaving}
+                  className="px-4 py-2 bg-indigo-600 text-white rounded-md hover:bg-indigo-700 text-sm disabled:opacity-50"
+                >
+                  {roundupSaving ? 'Saving…' : 'Save destination'}
+                </button>
+              </div>
+            </div>
+          )}
         </div>
 
         {/* Account Form */}
@@ -403,6 +627,32 @@ export default function AccountsPage() {
                     Set as main account
                   </label>
                 </div>
+
+                <div className="md:col-span-2 space-y-2 rounded-md border border-gray-200 dark:border-gray-600 p-3 bg-gray-50 dark:bg-gray-900/40">
+                  <p className="text-xs font-medium text-gray-700 dark:text-gray-300">Round-up savings</p>
+                  <div className="flex items-start gap-2">
+                    <input
+                      {...accountForm.register('roundUpOnExpenditure')}
+                      type="checkbox"
+                      id="roundUpOnExpenditure"
+                      className="h-4 w-4 mt-0.5 text-indigo-600 focus:ring-indigo-500 border-gray-300 rounded"
+                    />
+                    <label htmlFor="roundUpOnExpenditure" className="text-sm text-gray-700 dark:text-gray-300">
+                      Round up spending from this account to the next dollar (requires a savings destination above).
+                    </label>
+                  </div>
+                  <div className="flex items-start gap-2">
+                    <input
+                      {...accountForm.register('doesRoundupSave')}
+                      type="checkbox"
+                      id="doesRoundupSave"
+                      className="h-4 w-4 mt-0.5 text-indigo-600 focus:ring-indigo-500 border-gray-300 rounded"
+                    />
+                    <label htmlFor="doesRoundupSave" className="text-sm text-gray-700 dark:text-gray-300">
+                      Debit round-up spare change from this account (only one account per user; if unset, the spending account is debited).
+                    </label>
+                  </div>
+                </div>
               </div>
 
               <div className="flex justify-end space-x-3">
@@ -436,11 +686,9 @@ export default function AccountsPage() {
         )}
 
         {/* Add Expenditure modal (same as Expenditures page) */}
-        {showExpenditureForm && selectedAccount && (
+        {showExpenditureForm && (
           <div className="bg-white dark:bg-gray-800 rounded-lg shadow p-6 mb-6">
-            <h2 className="text-lg font-medium text-gray-900 dark:text-white mb-4">
-              Add New Expenditure – {selectedAccount.name}
-            </h2>
+            <h2 className="text-lg font-medium text-gray-900 dark:text-white mb-4">Add expenditure</h2>
             <form onSubmit={expenditureForm.handleSubmit(onExpenditureSubmit)} className="space-y-4">
               <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
                 <div>
@@ -553,14 +801,13 @@ export default function AccountsPage() {
                   onClick={() => {
                     expenditureForm.reset()
                     setShowExpenditureForm(false)
-                    setSelectedAccount(null)
                   }}
                   className="px-4 py-2 border border-gray-300 dark:border-gray-600 rounded-md text-gray-700 dark:text-gray-300 bg-white dark:bg-gray-700 hover:bg-gray-50 dark:hover:bg-gray-600"
                 >
                   Cancel
                 </button>
                 <button type="submit" className="px-4 py-2 bg-green-600 text-white rounded-md hover:bg-green-700">
-                  Add Expenditure
+                  Add expenditure
                 </button>
               </div>
             </form>
@@ -568,14 +815,31 @@ export default function AccountsPage() {
         )}
 
         {/* Deposit / Withdraw form */}
-        {showTransactionForm && transactionAccount && (
+        {showTransactionForm && (
           <div className="bg-white dark:bg-gray-800 rounded-lg shadow p-6 mb-6">
             <h2 className="text-lg font-medium text-gray-900 dark:text-white mb-4">
-              {transactionType === 'deposit' ? 'Deposit to' : 'Withdraw from'} – {transactionAccount.name}
+              {transactionType === 'deposit' ? 'Deposit' : 'Withdraw'}
             </h2>
             <form onSubmit={transactionForm.handleSubmit(onTransactionSubmit)} className="space-y-4">
               <input type="hidden" {...transactionForm.register('type')} />
               <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+                <div className="md:col-span-2">
+                  <label htmlFor="tx-account" className="block text-sm font-medium text-gray-700 dark:text-gray-300">
+                    Account
+                  </label>
+                  <select
+                    id="tx-account"
+                    value={transactionTargetAccountId}
+                    onChange={(e) => setTransactionTargetAccountId(e.target.value)}
+                    className="mt-1 block w-full px-3 py-2 border rounded-md shadow-sm sm:text-sm bg-white dark:bg-gray-700 text-gray-900 dark:text-white border-gray-300 dark:border-gray-600"
+                  >
+                    {accounts.map((acc) => (
+                      <option key={acc.id} value={acc.id}>
+                        {acc.name} ({acc.type}){acc.isMain ? ' – Primary' : ''}
+                      </option>
+                    ))}
+                  </select>
+                </div>
                 <div>
                   <label htmlFor="tx-amount" className="block text-sm font-medium text-gray-700 dark:text-gray-300">
                     Amount
@@ -624,7 +888,6 @@ export default function AccountsPage() {
                   onClick={() => {
                     transactionForm.reset()
                     setShowTransactionForm(false)
-                    setTransactionAccount(null)
                   }}
                   className="px-4 py-2 border border-gray-300 dark:border-gray-600 rounded-md text-gray-700 dark:text-gray-300 bg-white dark:bg-gray-700 hover:bg-gray-50 dark:hover:bg-gray-600"
                 >
@@ -641,6 +904,102 @@ export default function AccountsPage() {
                   )}
                 >
                   {isSubmittingTransaction ? 'Submitting…' : transactionType === 'deposit' ? 'Deposit' : 'Withdraw'}
+                </button>
+              </div>
+            </form>
+          </div>
+        )}
+
+        {showTransferForm && (
+          <div className="bg-white dark:bg-gray-800 rounded-lg shadow p-6 mb-6">
+            <h2 className="text-lg font-medium text-gray-900 dark:text-white mb-4">Transfer between accounts</h2>
+            <form onSubmit={transferForm.handleSubmit(onTransferSubmit)} className="space-y-4">
+              <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+                <div>
+                  <label htmlFor="xfer-from" className="block text-sm font-medium text-gray-700 dark:text-gray-300">
+                    From
+                  </label>
+                  <select
+                    id="xfer-from"
+                    {...transferForm.register('fromAccountId')}
+                    className={cn(
+                      'mt-1 block w-full px-3 py-2 border rounded-md shadow-sm sm:text-sm bg-white dark:bg-gray-700 text-gray-900 dark:text-white',
+                      transferForm.formState.errors.fromAccountId ? 'border-red-300 dark:border-red-500' : 'border-gray-300 dark:border-gray-600'
+                    )}
+                  >
+                    {accounts.map((acc) => (
+                      <option key={acc.id} value={acc.id}>
+                        {acc.name} ({acc.type})
+                      </option>
+                    ))}
+                  </select>
+                </div>
+                <div>
+                  <label htmlFor="xfer-to" className="block text-sm font-medium text-gray-700 dark:text-gray-300">
+                    To
+                  </label>
+                  <select
+                    id="xfer-to"
+                    {...transferForm.register('toAccountId')}
+                    className={cn(
+                      'mt-1 block w-full px-3 py-2 border rounded-md shadow-sm sm:text-sm bg-white dark:bg-gray-700 text-gray-900 dark:text-white',
+                      transferForm.formState.errors.toAccountId ? 'border-red-300 dark:border-red-500' : 'border-gray-300 dark:border-gray-600'
+                    )}
+                  >
+                    {accounts.map((acc) => (
+                      <option key={acc.id} value={acc.id}>
+                        {acc.name} ({acc.type})
+                      </option>
+                    ))}
+                  </select>
+                </div>
+                <div>
+                  <label htmlFor="xfer-amount" className="block text-sm font-medium text-gray-700 dark:text-gray-300">
+                    Amount
+                  </label>
+                  <div className="mt-1 relative">
+                    <div className="absolute inset-y-0 left-0 pl-3 flex items-center pointer-events-none">
+                      <DollarSign className="h-5 w-5 text-gray-400 dark:text-gray-500" />
+                    </div>
+                    <input
+                      {...transferForm.register('amount', { valueAsNumber: true })}
+                      id="xfer-amount"
+                      type="number"
+                      step="0.01"
+                      min="0"
+                      className={cn(
+                        'block w-full pl-10 pr-3 py-2 border rounded-md shadow-sm sm:text-sm bg-white dark:bg-gray-700 text-gray-900 dark:text-white',
+                        transferForm.formState.errors.amount ? 'border-red-300 dark:border-red-500' : 'border-gray-300 dark:border-gray-600'
+                      )}
+                    />
+                  </div>
+                </div>
+                <div>
+                  <label htmlFor="xfer-note" className="block text-sm font-medium text-gray-700 dark:text-gray-300">
+                    Note (optional)
+                  </label>
+                  <input
+                    {...transferForm.register('description')}
+                    id="xfer-note"
+                    type="text"
+                    className="mt-1 block w-full px-3 py-2 border rounded-md shadow-sm sm:text-sm bg-white dark:bg-gray-700 text-gray-900 dark:text-white border-gray-300 dark:border-gray-600"
+                  />
+                </div>
+              </div>
+              <div className="flex justify-end space-x-3">
+                <button
+                  type="button"
+                  onClick={() => setShowTransferForm(false)}
+                  className="px-4 py-2 border border-gray-300 dark:border-gray-600 rounded-md text-gray-700 dark:text-gray-300 bg-white dark:bg-gray-700 hover:bg-gray-50 dark:hover:bg-gray-600"
+                >
+                  Cancel
+                </button>
+                <button
+                  type="submit"
+                  disabled={isSubmittingTransfer}
+                  className="px-4 py-2 bg-slate-600 text-white rounded-md hover:bg-slate-700 disabled:opacity-50"
+                >
+                  {isSubmittingTransfer ? 'Transferring…' : 'Transfer'}
                 </button>
               </div>
             </form>
@@ -700,51 +1059,44 @@ export default function AccountsPage() {
                   </p>
                 </div>
 
-                <div className="space-y-2">
-                  <button
-                    onClick={() => handleDeposit(account)}
-                    className="w-full bg-green-600 text-white py-2 px-4 rounded-md hover:bg-green-700 flex items-center justify-center"
-                  >
-                    <ArrowDownCircle className="h-4 w-4 mr-2" />
-                    Deposit
-                  </button>
-                  <button
-                    onClick={() => handleWithdraw(account)}
-                    className="w-full bg-amber-600 text-white py-2 px-4 rounded-md hover:bg-amber-700 flex items-center justify-center"
-                  >
-                    <ArrowUpCircle className="h-4 w-4 mr-2" />
-                    Withdraw
-                  </button>
-                  <button
-                    onClick={() => handleAddExpenditure(account)}
-                    className="w-full border border-gray-300 dark:border-gray-600 text-gray-700 dark:text-gray-300 py-2 px-4 rounded-md hover:bg-gray-50 dark:hover:bg-gray-700 flex items-center justify-center"
-                  >
-                    <Plus className="h-4 w-4 mr-2" />
-                    Add Expenditure
-                  </button>
-                  
+                <div className="space-y-2 mt-4">
                   {account.accountTransactions && account.accountTransactions.length > 0 && (
-                    <div className="mt-4">
+                    <div>
                       <h4 className="text-sm font-medium text-gray-900 dark:text-white mb-2">Recent activity</h4>
                       <div className="space-y-1">
-                        {account.accountTransactions?.slice(0, 3).map((transaction) => {
-                          const label = transaction.description.replace(/^Expenditure:\s*/i, '').trim() || transaction.description
+                        {account.accountTransactions?.slice(0, 5).map((transaction) => {
+                          const cp = transaction.counterpartyAccountId
+                          const isOut = transaction.type === 'transfer_out'
+                          const isIn = transaction.type === 'transfer_in'
+                          const label = isOut
+                            ? `Transfer → ${accountNameById(cp)}`
+                            : isIn
+                              ? `Transfer ← ${accountNameById(cp)}`
+                              : transaction.description.replace(/^Expenditure:\s*/i, '').trim() || transaction.description
+                          const isCredit =
+                            transaction.type === 'deposit' || transaction.type === 'transfer_in'
                           return (
                             <div key={transaction.id} className="flex items-center justify-between gap-2 text-sm min-w-0">
                               <div className="flex items-center space-x-2 min-w-0 overflow-hidden">
-                                {transaction.type === 'deposit' ? null : (
+                                {isIn ? (
+                                  <ArrowDownCircle className="h-3 w-3 text-green-500 flex-shrink-0" />
+                                ) : isOut ? (
+                                  <ArrowLeftRight className="h-3 w-3 text-slate-500 flex-shrink-0" />
+                                ) : transaction.type === 'deposit' ? (
+                                  <ArrowDownCircle className="h-3 w-3 text-green-500 flex-shrink-0" />
+                                ) : (
                                   <TrendingDown className="h-3 w-3 text-red-500 flex-shrink-0" />
                                 )}
-                                <span className="text-gray-600 dark:text-gray-400 truncate">
-                                  {label}
-                                </span>
+                                <span className="text-gray-600 dark:text-gray-400 truncate">{label}</span>
                               </div>
-                              <span className={`font-medium flex-shrink-0 ${
-                                transaction.type === 'deposit'
-                                  ? 'text-green-600 dark:text-green-400'
-                                  : 'text-red-600 dark:text-red-400'
-                              }`}>
-                                {transaction.type === 'deposit' ? '+' : '-'}${transaction.amount.toFixed(2)}
+                              <span
+                                className={`font-medium flex-shrink-0 ${
+                                  isCredit
+                                    ? 'text-green-600 dark:text-green-400'
+                                    : 'text-red-600 dark:text-red-400'
+                                }`}
+                              >
+                                {isCredit ? '+' : '-'}${transaction.amount.toFixed(2)}
                               </span>
                             </div>
                           )

--- a/src/app/api/account-transfers/__tests__/route.test.ts
+++ b/src/app/api/account-transfers/__tests__/route.test.ts
@@ -1,0 +1,115 @@
+import { NextRequest } from 'next/server'
+import { POST } from '../route'
+import { prisma } from '@/lib/prisma'
+import { requireApiAuth } from '@/lib/api-auth'
+import { NextResponse } from 'next/server'
+
+jest.mock('@/lib/api-auth', () => ({ requireApiAuth: jest.fn() }))
+jest.mock('@/lib/prisma', () => ({
+  prisma: {
+    account: { findFirst: jest.fn() },
+    $transaction: jest.fn(),
+  },
+}))
+
+const mockRequireApiAuth = requireApiAuth as jest.MockedFunction<typeof requireApiAuth>
+const mockPrisma = prisma as jest.Mocked<typeof prisma>
+
+describe('/api/account-transfers', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    mockRequireApiAuth.mockResolvedValue({ userId: 'user-1' })
+  })
+
+  it('creates paired transfer_out and transfer_in and updates balances', async () => {
+    const fromId = 'a1b2c3d4-e5f6-4789-a012-3456789abcde'
+    const toId = 'b2c3d4e5-f6a7-4890-b123-456789abcdef'
+
+    mockPrisma.account.findFirst
+      .mockResolvedValueOnce({ id: fromId, balance: 200, userId: 'user-1' } as never)
+      .mockResolvedValueOnce({ id: toId, balance: 50, userId: 'user-1' } as never)
+
+    const accountTransactionCreate = jest.fn().mockResolvedValue({})
+    const accountUpdate = jest.fn().mockResolvedValue({})
+    mockPrisma.$transaction.mockImplementation(async (fn: (tx: unknown) => Promise<unknown>) =>
+      fn({
+        accountTransaction: { create: accountTransactionCreate },
+        account: { update: accountUpdate },
+      })
+    )
+
+    const req = {
+      json: jest.fn().mockResolvedValue({
+        fromAccountId: fromId,
+        toAccountId: toId,
+        amount: 25,
+        description: 'Move cash',
+      }),
+    } as unknown as NextRequest
+
+    const res = await POST(req)
+    const data = await res.json()
+
+    expect(res.status).toBe(200)
+    expect(data.transferPairId).toBeDefined()
+    expect(accountTransactionCreate).toHaveBeenCalledTimes(2)
+    expect(accountTransactionCreate.mock.calls[0][0].data.type).toBe('transfer_out')
+    expect(accountTransactionCreate.mock.calls[1][0].data.type).toBe('transfer_in')
+    expect(accountUpdate).toHaveBeenCalledTimes(2)
+  })
+
+  it('returns 400 when insufficient funds', async () => {
+    const fromId = 'a1b2c3d4-e5f6-4789-a012-3456789abcde'
+    const toId = 'b2c3d4e5-f6a7-4890-b123-456789abcdef'
+
+    mockPrisma.account.findFirst
+      .mockResolvedValueOnce({ id: fromId, balance: 10, userId: 'user-1' } as never)
+      .mockResolvedValueOnce({ id: toId, balance: 0, userId: 'user-1' } as never)
+
+    const req = {
+      json: jest.fn().mockResolvedValue({
+        fromAccountId: fromId,
+        toAccountId: toId,
+        amount: 25,
+      }),
+    } as unknown as NextRequest
+
+    const res = await POST(req)
+    const data = await res.json()
+    expect(res.status).toBe(400)
+    expect(data.error).toBe('Insufficient funds')
+  })
+
+  it('returns 404 when an account is missing', async () => {
+    const fromId = 'a1b2c3d4-e5f6-4789-a012-3456789abcde'
+    const toId = 'b2c3d4e5-f6a7-4890-b123-456789abcdef'
+
+    mockPrisma.account.findFirst.mockResolvedValueOnce({ id: fromId, balance: 100 } as never).mockResolvedValueOnce(null)
+
+    const req = {
+      json: jest.fn().mockResolvedValue({
+        fromAccountId: fromId,
+        toAccountId: toId,
+        amount: 5,
+      }),
+    } as unknown as NextRequest
+
+    const res = await POST(req)
+    expect(res.status).toBe(404)
+  })
+
+  it('returns 401 when not authenticated', async () => {
+    mockRequireApiAuth.mockResolvedValue(
+      NextResponse.json({ error: 'Authentication required' }, { status: 401 })
+    )
+    const req = {
+      json: jest.fn().mockResolvedValue({
+        fromAccountId: 'a1b2c3d4-e5f6-4789-a012-3456789abcde',
+        toAccountId: 'b2c3d4e5-f6a7-4890-b123-456789abcdef',
+        amount: 1,
+      }),
+    } as unknown as NextRequest
+    const res = await POST(req)
+    expect(res.status).toBe(401)
+  })
+})

--- a/src/app/api/account-transfers/route.ts
+++ b/src/app/api/account-transfers/route.ts
@@ -1,0 +1,77 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { randomUUID } from 'crypto'
+import { z } from 'zod'
+import { accountTransferSchema } from '@/lib/validations'
+import { prisma, type TransactionClient } from '@/lib/prisma'
+import { requireApiAuth } from '@/lib/api-auth'
+
+export async function POST(request: NextRequest) {
+  try {
+    const auth = await requireApiAuth(request)
+    if (auth instanceof NextResponse) return auth
+    const { userId } = auth
+
+    const body = await request.json()
+    const { fromAccountId, toAccountId, amount, description } = accountTransferSchema.parse(body)
+
+    const label = (description?.trim() || 'Transfer').slice(0, 500)
+
+    const [fromAccount, toAccount] = await Promise.all([
+      prisma.account.findFirst({ where: { id: fromAccountId, userId } }),
+      prisma.account.findFirst({ where: { id: toAccountId, userId } }),
+    ])
+
+    if (!fromAccount || !toAccount) {
+      return NextResponse.json({ error: 'Account not found' }, { status: 404 })
+    }
+
+    if (fromAccount.balance < amount) {
+      return NextResponse.json({ error: 'Insufficient funds' }, { status: 400 })
+    }
+
+    const pairId = randomUUID()
+
+    const result = await prisma.$transaction(async (tx: TransactionClient) => {
+      const out = await tx.accountTransaction.create({
+        data: {
+          accountId: fromAccountId,
+          type: 'transfer_out',
+          amount,
+          description: label,
+          userId,
+          transferPairId: pairId,
+          counterpartyAccountId: toAccountId,
+        },
+      })
+      const inn = await tx.accountTransaction.create({
+        data: {
+          accountId: toAccountId,
+          type: 'transfer_in',
+          amount,
+          description: label,
+          userId,
+          transferPairId: pairId,
+          counterpartyAccountId: fromAccountId,
+        },
+      })
+      await tx.account.update({
+        where: { id: fromAccountId },
+        data: { balance: { decrement: amount } },
+      })
+      await tx.account.update({
+        where: { id: toAccountId },
+        data: { balance: { increment: amount } },
+      })
+      return { transferPairId: pairId, out, in: inn }
+    })
+
+    return NextResponse.json(result)
+  } catch (error) {
+    if (error instanceof z.ZodError) {
+      const message =
+        error.issues.map((issue) => issue.message).join('; ') || 'Validation failed'
+      return NextResponse.json({ error: message }, { status: 400 })
+    }
+    return NextResponse.json({ error: 'Failed to create transfer' }, { status: 500 })
+  }
+}

--- a/src/app/api/accounts/[id]/__tests__/route.test.ts
+++ b/src/app/api/accounts/[id]/__tests__/route.test.ts
@@ -54,6 +54,24 @@ describe('/api/accounts/[id]', () => {
       )
     })
 
+    it('clears doesRoundupSave on other accounts when set to true', async () => {
+      mockPrisma.account.updateMany.mockResolvedValue({} as any)
+      mockPrisma.account.update.mockResolvedValue({ id: 'acc-1' } as any)
+
+      const req = {
+        json: jest.fn().mockResolvedValue({
+          doesRoundupSave: true,
+        }),
+      } as unknown as NextRequest
+
+      await PUT(req, { params: params() })
+
+      expect(mockPrisma.account.updateMany).toHaveBeenCalledWith({
+        where: { userId: 'user-1', id: { not: 'acc-1' } },
+        data: { doesRoundupSave: false },
+      })
+    })
+
     it('returns 401 when not authenticated', async () => {
       mockRequireApiAuth.mockResolvedValue(
         NextResponse.json({ error: 'Authentication required' }, { status: 401 })

--- a/src/app/api/accounts/[id]/route.ts
+++ b/src/app/api/accounts/[id]/route.ts
@@ -15,7 +15,17 @@ export async function PUT(
 
     const { id } = await params
     const body = await request.json()
-    const { name, type, subtype, institution, institutionId, balance, isMain } = updateAccountSchema.parse(body)
+    const {
+      name,
+      type,
+      subtype,
+      institution,
+      institutionId,
+      balance,
+      isMain,
+      roundUpOnExpenditure,
+      doesRoundupSave,
+    } = updateAccountSchema.parse(body)
 
     // If this is being set as main account, unset other main accounts
     if (isMain) {
@@ -25,9 +35,26 @@ export async function PUT(
       })
     }
 
+    if (doesRoundupSave === true) {
+      await prisma.account.updateMany({
+        where: { userId, id: { not: id } },
+        data: { doesRoundupSave: false }
+      })
+    }
+
     const account = await prisma.account.update({
       where: { id, userId },
-      data: { name, type, subtype, institution, institutionId, balance, isMain },
+      data: {
+        name,
+        type,
+        subtype,
+        institution,
+        institutionId,
+        balance,
+        isMain,
+        roundUpOnExpenditure,
+        doesRoundupSave,
+      },
       include: {
         accountTransactions: {
           orderBy: { createdAt: 'desc' },

--- a/src/app/api/accounts/__tests__/route.test.ts
+++ b/src/app/api/accounts/__tests__/route.test.ts
@@ -111,6 +111,33 @@ describe('/api/accounts', () => {
       })
     })
 
+    it('clears doesRoundupSave on other accounts when doesRoundupSave is true', async () => {
+      mockPrisma.account.updateMany.mockResolvedValue({} as any)
+      mockPrisma.account.create.mockResolvedValue({ id: 'acc-new' } as any)
+
+      const req = {
+        json: jest.fn().mockResolvedValue({
+          name: 'Checking',
+          type: 'checking',
+          balance: 0,
+          isMain: false,
+          doesRoundupSave: true,
+        }),
+      } as unknown as NextRequest
+
+      await POST(req)
+
+      expect(mockPrisma.account.updateMany).toHaveBeenCalledWith({
+        where: { userId: 'user-1' },
+        data: { doesRoundupSave: false },
+      })
+      expect(mockPrisma.account.create).toHaveBeenCalledWith(
+        expect.objectContaining({
+          data: expect.objectContaining({ doesRoundupSave: true }),
+        })
+      )
+    })
+
     it('returns 500 on validation error', async () => {
       const req = {
         json: jest.fn().mockResolvedValue({ name: '', type: 'depository' }),

--- a/src/app/api/accounts/route.ts
+++ b/src/app/api/accounts/route.ts
@@ -38,13 +38,30 @@ export async function POST(request: NextRequest) {
     const { userId } = auth
 
     const body = await request.json()
-    const { name, type, subtype, institution, institutionId, balance, isMain } = accountSchema.parse(body)
+    const {
+      name,
+      type,
+      subtype,
+      institution,
+      institutionId,
+      balance,
+      isMain,
+      roundUpOnExpenditure,
+      doesRoundupSave,
+    } = accountSchema.parse(body)
 
     // If this is being set as main account, unset other main accounts
     if (isMain) {
       await prisma.account.updateMany({
         where: { userId, isMain: true },
         data: { isMain: false }
+      })
+    }
+
+    if (doesRoundupSave) {
+      await prisma.account.updateMany({
+        where: { userId },
+        data: { doesRoundupSave: false }
       })
     }
 
@@ -57,6 +74,8 @@ export async function POST(request: NextRequest) {
         institutionId,
         balance,
         isMain,
+        roundUpOnExpenditure,
+        doesRoundupSave,
         userId
       },
       include: {

--- a/src/app/api/expenditures/__tests__/route.test.ts
+++ b/src/app/api/expenditures/__tests__/route.test.ts
@@ -5,35 +5,77 @@ import { requireApiAuth } from '@/lib/api-auth'
 import { NextResponse } from 'next/server'
 
 jest.mock('@/lib/api-auth', () => ({ requireApiAuth: jest.fn() }))
-jest.mock('@/lib/prisma', () => {
-  const mockTx = {
-    expenditure: { create: jest.fn().mockResolvedValue({ id: 'exp-1' }) },
-    accountTransaction: { create: jest.fn().mockResolvedValue({}) },
-    account: { update: jest.fn().mockResolvedValue({}) },
-  }
-  return {
-    prisma: {
-      expenditure: { findMany: jest.fn(), count: jest.fn() },
-      account: { findFirst: jest.fn() },
-      $transaction: jest.fn((fn: (tx: any) => Promise<any>) => fn(mockTx)),
-    },
-  }
-})
+
+jest.mock('@/lib/prisma', () => ({
+  prisma: {
+    expenditure: { findMany: jest.fn(), count: jest.fn() },
+    account: { findFirst: jest.fn() },
+    $transaction: jest.fn(),
+  },
+}))
 
 const mockRequireApiAuth = requireApiAuth as jest.MockedFunction<typeof requireApiAuth>
 const mockPrisma = prisma as jest.Mocked<typeof prisma>
 
+function buildTxMock(opts: {
+  userRoundup?: string | null
+  eff: { id: string; balance: number; roundUpOnExpenditure: boolean }
+  accountFindFirst?: jest.Mock
+  accountFindUnique?: jest.Mock
+}) {
+  const accountTransactionCreate = jest.fn().mockResolvedValue({})
+  const expenditureCreate = jest.fn().mockResolvedValue({ id: 'exp-1' })
+  const accountUpdate = jest.fn().mockResolvedValue({})
+  const userFindUnique = jest
+    .fn()
+    .mockResolvedValue({ roundupSavingsAccountId: opts.userRoundup ?? null })
+
+  const accountFindFirst =
+    opts.accountFindFirst ??
+    jest.fn().mockResolvedValue(opts.eff)
+
+  const accountFindUnique =
+    opts.accountFindUnique ??
+    jest.fn().mockImplementation(async (args: { where: { id: string } }) => ({
+      id: args.where.id,
+      balance: 500,
+    }))
+
+  const mockTx = {
+    user: { findUnique: userFindUnique },
+    expenditure: { create: expenditureCreate },
+    accountTransaction: { create: accountTransactionCreate },
+    account: {
+      findFirst: accountFindFirst,
+      findUnique: accountFindUnique,
+      update: accountUpdate,
+    },
+  }
+
+  return { mockTx, accountTransactionCreate }
+}
+
 describe('/api/expenditures', () => {
   beforeEach(() => {
-    jest.clearAllMocks()
+    mockRequireApiAuth.mockReset()
     mockRequireApiAuth.mockResolvedValue({ userId: 'user-1' })
+    mockPrisma.expenditure.findMany.mockReset()
+    mockPrisma.expenditure.count.mockReset()
+    mockPrisma.account.findFirst.mockReset()
+    mockPrisma.$transaction.mockReset()
+    mockPrisma.$transaction.mockImplementation((fn: (tx: unknown) => Promise<unknown>) => {
+      const { mockTx } = buildTxMock({
+        eff: { id: 'acc-1', balance: 1000, roundUpOnExpenditure: false },
+      })
+      return fn(mockTx)
+    })
   })
 
   describe('GET', () => {
     it('returns expenditures with pagination', async () => {
       mockPrisma.expenditure.findMany.mockResolvedValue([
         { id: 'exp-1', title: 'Coffee', userId: 'user-1' },
-      ] as any)
+      ] as never)
       mockPrisma.expenditure.count.mockResolvedValue(1)
 
       const req = {
@@ -128,9 +170,17 @@ describe('/api/expenditures', () => {
 
   describe('POST', () => {
     it('creates expenditure successfully', async () => {
-      mockPrisma.account.findFirst
-        .mockResolvedValueOnce(null)
-        .mockResolvedValueOnce({ id: 'acc-1' } as any)
+      let accountTransactionCreate: jest.Mock = jest.fn()
+      // No accountId in body → first findFirst is primary account lookup
+      mockPrisma.account.findFirst.mockResolvedValueOnce({ id: 'acc-1' } as never)
+
+      mockPrisma.$transaction.mockImplementation((fn: (tx: unknown) => Promise<unknown>) => {
+        const built = buildTxMock({
+          eff: { id: 'acc-1', balance: 1000, roundUpOnExpenditure: false },
+        })
+        accountTransactionCreate = built.accountTransactionCreate
+        return fn(built.mockTx)
+      })
 
       const req = {
         json: jest.fn().mockResolvedValue({
@@ -146,11 +196,19 @@ describe('/api/expenditures', () => {
       expect(res.status).toBe(200)
       expect(data.id).toBe('exp-1')
       expect(mockPrisma.$transaction).toHaveBeenCalled()
+      expect(accountTransactionCreate).toHaveBeenCalledTimes(1)
     })
 
     it('uses body accountId when valid for user', async () => {
       const accountId = 'a1b2c3d4-e5f6-4789-a012-3456789abcde'
-      mockPrisma.account.findFirst.mockResolvedValueOnce({ id: accountId } as any)
+      mockPrisma.account.findFirst.mockResolvedValueOnce({ id: accountId } as never)
+
+      mockPrisma.$transaction.mockImplementation((fn: (tx: unknown) => Promise<unknown>) => {
+        const built = buildTxMock({
+          eff: { id: accountId, balance: 1000, roundUpOnExpenditure: false },
+        })
+        return fn(built.mockTx)
+      })
 
       const req = {
         json: jest.fn().mockResolvedValue({
@@ -169,7 +227,7 @@ describe('/api/expenditures', () => {
       })
     })
 
-    it('returns 500 on validation error', async () => {
+    it('returns 400 on validation error', async () => {
       const req = {
         json: jest.fn().mockResolvedValue({
           title: '',
@@ -179,8 +237,79 @@ describe('/api/expenditures', () => {
       } as unknown as NextRequest
       const res = await POST(req)
       const data = await res.json()
-      expect(res.status).toBe(500)
-      expect(data.error).toBe('Failed to create expenditure')
+      expect(res.status).toBe(400)
+      expect(data.error).toBeDefined()
+    })
+
+    it('creates round-up deposit and extra withdrawal when configured', async () => {
+      const savingsId = 'b2c3d4e5-f6a7-4890-b123-456789abcdef'
+      mockPrisma.account.findFirst.mockResolvedValueOnce({ id: 'acc-1' } as never)
+
+      const findFirst = jest
+        .fn()
+        .mockResolvedValueOnce({
+          id: 'acc-1',
+          balance: 100,
+          roundUpOnExpenditure: true,
+        })
+        .mockResolvedValueOnce({ id: savingsId })
+        .mockResolvedValueOnce(null)
+
+      const findUnique = jest
+        .fn()
+        .mockResolvedValueOnce({ id: 'acc-1', balance: 100 })
+        .mockResolvedValueOnce({ id: savingsId, balance: 0 })
+
+      let accountTransactionCreate: jest.Mock = jest.fn()
+      mockPrisma.$transaction.mockImplementation((fn: (tx: unknown) => Promise<unknown>) => {
+        const built = buildTxMock({
+          userRoundup: savingsId,
+          eff: { id: 'acc-1', balance: 100, roundUpOnExpenditure: true },
+          accountFindFirst: findFirst,
+          accountFindUnique: findUnique,
+        })
+        accountTransactionCreate = built.accountTransactionCreate
+        return fn(built.mockTx)
+      })
+
+      const req = {
+        json: jest.fn().mockResolvedValue({
+          title: 'Coffee',
+          amount: 3.45,
+          categoryId: 'cat-1',
+        }),
+      } as unknown as NextRequest
+
+      const res = await POST(req)
+      expect(res.status).toBe(200)
+      expect(accountTransactionCreate).toHaveBeenCalledTimes(3)
+    })
+
+    it('skips round-up when amount is already a whole dollar', async () => {
+      const savingsId = 'b2c3d4e5-f6a7-4890-b123-456789abcdef'
+      mockPrisma.account.findFirst.mockResolvedValueOnce({ id: 'acc-1' } as never)
+
+      let accountTransactionCreate: jest.Mock = jest.fn()
+      mockPrisma.$transaction.mockImplementation((fn: (tx: unknown) => Promise<unknown>) => {
+        const built = buildTxMock({
+          userRoundup: savingsId,
+          eff: { id: 'acc-1', balance: 100, roundUpOnExpenditure: true },
+        })
+        accountTransactionCreate = built.accountTransactionCreate
+        return fn(built.mockTx)
+      })
+
+      const req = {
+        json: jest.fn().mockResolvedValue({
+          title: 'Coffee',
+          amount: 5,
+          categoryId: 'cat-1',
+        }),
+      } as unknown as NextRequest
+
+      const res = await POST(req)
+      expect(res.status).toBe(200)
+      expect(accountTransactionCreate).toHaveBeenCalledTimes(1)
     })
   })
 })

--- a/src/app/api/expenditures/route.ts
+++ b/src/app/api/expenditures/route.ts
@@ -1,8 +1,10 @@
 import { NextRequest, NextResponse } from 'next/server'
+import { z } from 'zod'
 import { expenditureSchema } from '@/lib/validations'
 import { prisma, type TransactionClient } from '@/lib/prisma'
 import { decryptQueryResult } from '@/lib/prisma-encryption-middleware'
 import { requireApiAuth } from '@/lib/api-auth'
+import { roundUpSpareCents } from '@/lib/roundup'
 
 type ExpenditureWhere = {
   userId: string
@@ -110,22 +112,49 @@ export async function POST(request: NextRequest) {
       effectiveAccount = primary
     }
 
+    const spare = roundUpSpareCents(amount)
+
     const result = await prisma.$transaction(async (tx: TransactionClient) => {
+      const user = await tx.user.findUnique({
+        where: { id: userId },
+        select: { roundupSavingsAccountId: true }
+      })
+
+      let effFull: {
+        id: string
+        balance: number
+        roundUpOnExpenditure: boolean
+      } | null = null
+
+      if (effectiveAccount) {
+        const row = await tx.account.findFirst({
+          where: { id: effectiveAccount.id, userId },
+          select: { id: true, balance: true, roundUpOnExpenditure: true }
+        })
+        if (!row) {
+          throw Object.assign(new Error('Account not found'), { code: 'BAD_ACCOUNT' })
+        }
+        effFull = row
+        if (effFull.balance < amount) {
+          throw Object.assign(new Error('Insufficient funds'), { code: 'INSUFFICIENT' })
+        }
+      }
+
       const expenditure = await tx.expenditure.create({
         data: {
           title,
           amount,
           categoryId,
           userId,
-          accountId: effectiveAccount?.id ?? null,
+          accountId: effFull?.id ?? null,
           ...(createdAt && { createdAt })
         }
       })
 
-      if (effectiveAccount) {
+      if (effFull) {
         await tx.accountTransaction.create({
           data: {
-            accountId: effectiveAccount.id,
+            accountId: effFull.id,
             type: 'withdrawal',
             amount,
             description: `Expenditure: ${title}`,
@@ -133,16 +162,115 @@ export async function POST(request: NextRequest) {
           }
         })
         await tx.account.update({
-          where: { id: effectiveAccount.id },
+          where: { id: effFull.id },
           data: { balance: { decrement: amount } }
         })
+      }
+
+      const canRoundUp =
+        effFull?.roundUpOnExpenditure &&
+        !!user?.roundupSavingsAccountId &&
+        spare > 1e-6
+
+      if (canRoundUp) {
+        const savingsRow = await tx.account.findFirst({
+          where: { id: user!.roundupSavingsAccountId!, userId },
+          select: { id: true }
+        })
+        if (savingsRow) {
+          const designatedSource = await tx.account.findFirst({
+            where: { userId, doesRoundupSave: true },
+            select: { id: true }
+          })
+          const sourceId = designatedSource?.id ?? effFull!.id
+
+          let sourceAcc = await tx.account.findUnique({
+            where: { id: sourceId },
+            select: { id: true, balance: true }
+          })
+          let destAcc = await tx.account.findUnique({
+            where: { id: savingsRow.id },
+            select: { id: true, balance: true }
+          })
+
+          if (!sourceAcc || !destAcc) {
+            throw Object.assign(new Error('Round-up account resolution failed'), { code: 'ROUNDUP' })
+          }
+
+          const rdesc = `Round-up (expenditure): ${title}`
+
+          if (sourceAcc.id === destAcc.id) {
+            if (sourceAcc.balance < spare) {
+              throw Object.assign(new Error('Insufficient funds for round-up'), { code: 'INSUFFICIENT' })
+            }
+            await tx.accountTransaction.create({
+              data: {
+                accountId: sourceAcc.id,
+                type: 'withdrawal',
+                amount: spare,
+                description: rdesc,
+                userId
+              }
+            })
+            await tx.account.update({
+              where: { id: sourceAcc.id },
+              data: { balance: { decrement: spare } }
+            })
+          } else {
+            if (sourceAcc.balance < spare) {
+              throw Object.assign(new Error('Insufficient funds for round-up'), { code: 'INSUFFICIENT' })
+            }
+            await tx.accountTransaction.create({
+              data: {
+                accountId: sourceAcc.id,
+                type: 'withdrawal',
+                amount: spare,
+                description: rdesc,
+                userId,
+                counterpartyAccountId: destAcc.id
+              }
+            })
+            await tx.accountTransaction.create({
+              data: {
+                accountId: destAcc.id,
+                type: 'deposit',
+                amount: spare,
+                description: rdesc,
+                userId,
+                counterpartyAccountId: sourceAcc.id
+              }
+            })
+            await tx.account.update({
+              where: { id: sourceAcc.id },
+              data: { balance: { decrement: spare } }
+            })
+            await tx.account.update({
+              where: { id: destAcc.id },
+              data: { balance: { increment: spare } }
+            })
+          }
+        }
       }
 
       return expenditure
     })
 
     return NextResponse.json(result)
-  } catch (_error) {
+  } catch (error) {
+    if (error instanceof z.ZodError) {
+      const message =
+        error.issues.map((issue) => issue.message).join('; ') || 'Validation failed'
+      return NextResponse.json({ error: message }, { status: 400 })
+    }
+    if (error && typeof error === 'object' && 'code' in error) {
+      const code = (error as { code: string }).code
+      if (code === 'INSUFFICIENT') {
+        return NextResponse.json({ error: 'Insufficient funds' }, { status: 400 })
+      }
+      if (code === 'BAD_ACCOUNT') {
+        return NextResponse.json({ error: 'Account not found' }, { status: 400 })
+      }
+    }
     return NextResponse.json(
       { error: 'Failed to create expenditure' },
       { status: 500 }

--- a/src/app/api/user/roundup-settings/route.ts
+++ b/src/app/api/user/roundup-settings/route.ts
@@ -1,0 +1,59 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { z } from 'zod'
+import { roundupSettingsSchema } from '@/lib/validations'
+import { prisma } from '@/lib/prisma'
+import { requireApiAuth } from '@/lib/api-auth'
+
+export async function GET(request: NextRequest) {
+  try {
+    const auth = await requireApiAuth(request)
+    if (auth instanceof NextResponse) return auth
+    const { userId } = auth
+
+    const user = await prisma.user.findUnique({
+      where: { id: userId },
+      select: { roundupSavingsAccountId: true },
+    })
+
+    return NextResponse.json({
+      roundupSavingsAccountId: user?.roundupSavingsAccountId ?? null,
+    })
+  } catch (_error) {
+    return NextResponse.json({ error: 'Failed to load round-up settings' }, { status: 500 })
+  }
+}
+
+export async function PUT(request: NextRequest) {
+  try {
+    const auth = await requireApiAuth(request)
+    if (auth instanceof NextResponse) return auth
+    const { userId } = auth
+
+    const body = await request.json()
+    const { roundupSavingsAccountId } = roundupSettingsSchema.parse(body)
+
+    if (roundupSavingsAccountId !== null) {
+      const acc = await prisma.account.findFirst({
+        where: { id: roundupSavingsAccountId, userId },
+        select: { id: true },
+      })
+      if (!acc) {
+        return NextResponse.json({ error: 'Savings account not found' }, { status: 400 })
+      }
+    }
+
+    await prisma.user.update({
+      where: { id: userId },
+      data: { roundupSavingsAccountId },
+    })
+
+    return NextResponse.json({ roundupSavingsAccountId })
+  } catch (error) {
+    if (error instanceof z.ZodError) {
+      const message =
+        error.issues.map((issue) => issue.message).join('; ') || 'Validation failed'
+      return NextResponse.json({ error: message }, { status: 400 })
+    }
+    return NextResponse.json({ error: 'Failed to save round-up settings' }, { status: 500 })
+  }
+}

--- a/src/app/expenditures/page.tsx
+++ b/src/app/expenditures/page.tsx
@@ -9,6 +9,7 @@ import { Search, Receipt, ChevronLeft, ChevronRight, Plus, DollarSign, Edit, Tra
 import { Navigation } from '@/components/Navigation'
 import { useUser } from '@/contexts/UserContext'
 import { expenditureSchema, ExpenditureInput } from '@/lib/validations'
+import { roundUpSpareCents } from '@/lib/roundup'
 import { cn } from '@/lib/utils'
 
 interface Expenditure {
@@ -34,6 +35,8 @@ interface Account {
   type: string
   balance: number
   isMain?: boolean
+  roundUpOnExpenditure?: boolean
+  doesRoundupSave?: boolean
 }
 
 const PAGE_SIZE = 20
@@ -53,6 +56,7 @@ function ExpendituresContent() {
   const [page, setPage] = useState(() => Math.max(1, parseInt(searchParams.get('page') ?? '1', 10)))
   const [showExpenditureForm, setShowExpenditureForm] = useState(false)
   const [editingExpenditure, setEditingExpenditure] = useState<Expenditure | null>(null)
+  const [roundupSavingsAccountId, setRoundupSavingsAccountId] = useState<string | null>(null)
 
   const expenditureForm = useForm<ExpenditureInput>({
     resolver: zodResolver(expenditureSchema) as Resolver<ExpenditureInput>,
@@ -90,6 +94,20 @@ function ExpendituresContent() {
     }
   }, [])
 
+  const fetchRoundupSettings = useCallback(async () => {
+    try {
+      const response = await fetch('/api/user/roundup-settings')
+      if (response.ok) {
+        const data = await response.json()
+        setRoundupSavingsAccountId(data.roundupSavingsAccountId ?? null)
+      } else {
+        setRoundupSavingsAccountId(null)
+      }
+    } catch {
+      setRoundupSavingsAccountId(null)
+    }
+  }, [])
+
   const fetchExpenditures = useCallback(async () => {
     if (!user) return
     setIsLoading(true)
@@ -122,8 +140,9 @@ function ExpendituresContent() {
     if (user && !userLoading) {
       fetchCategories()
       fetchAccounts()
+      fetchRoundupSettings()
     }
-  }, [user, userLoading, fetchCategories, fetchAccounts])
+  }, [user, userLoading, fetchCategories, fetchAccounts, fetchRoundupSettings])
 
   useEffect(() => {
     if (user && !userLoading) {
@@ -242,6 +261,22 @@ function ExpendituresContent() {
       </div>
     )
   }
+
+  const watchedAccountId = expenditureForm.watch('accountId')
+  const watchedAmount = expenditureForm.watch('amount')
+  const primaryAccount = accounts.find((a) => a.isMain)
+  const effectiveSpendAccount =
+    accounts.find((a) => a.id === (watchedAccountId || '')) ?? primaryAccount ?? null
+  const spare =
+    typeof watchedAmount === 'number' && watchedAmount > 0 ? roundUpSpareCents(watchedAmount) : 0
+  const savingsName = accounts.find((a) => a.id === roundupSavingsAccountId)?.name ?? 'savings'
+  const roundupSourceAccount = accounts.find((a) => a.doesRoundupSave) ?? effectiveSpendAccount
+  const showRoundupHint =
+    !editingExpenditure &&
+    showExpenditureForm &&
+    Boolean(effectiveSpendAccount?.roundUpOnExpenditure) &&
+    Boolean(roundupSavingsAccountId) &&
+    spare > 0
 
   return (
     <div className="min-h-screen bg-gray-50 dark:bg-gray-900">
@@ -382,6 +417,12 @@ function ExpendituresContent() {
                     <p className="mt-1 text-sm text-red-600 dark:text-red-400">{expenditureForm.formState.errors.accountId.message}</p>
                   )}
                 </div>
+                {showRoundupHint && (
+                  <p className="md:col-span-2 text-sm text-indigo-700 dark:text-indigo-300 bg-indigo-50 dark:bg-indigo-950/40 border border-indigo-200 dark:border-indigo-800 rounded-md px-3 py-2">
+                    Round-up: an extra ${spare.toFixed(2)} will move to {savingsName} (debited from{' '}
+                    {roundupSourceAccount?.name ?? 'the spending account'}).
+                  </p>
+                )}
               </div>
               <div className="flex justify-end space-x-3">
                 <button

--- a/src/lib/roundup.ts
+++ b/src/lib/roundup.ts
@@ -1,0 +1,5 @@
+/** Spare change to reach the next whole dollar (0 if already whole). */
+export function roundUpSpareCents(amount: number): number {
+  const spare = Math.ceil(amount) - amount
+  return spare > 1e-6 ? spare : 0
+}

--- a/src/lib/validations.ts
+++ b/src/lib/validations.ts
@@ -114,9 +114,27 @@ export const accountSchema = z.object({
   institutionId: z.string().optional(),
   balance: z.number().min(0, 'Balance must be non-negative').optional().default(0),
   isMain: z.boolean().optional().default(false),
+  roundUpOnExpenditure: z.boolean().optional().default(false),
+  doesRoundupSave: z.boolean().optional().default(false),
 })
 
 export const updateAccountSchema = accountSchema.partial()
+
+export const roundupSettingsSchema = z.object({
+  roundupSavingsAccountId: z.union([z.string().uuid(), z.null()]),
+})
+
+export const accountTransferSchema = z
+  .object({
+    fromAccountId: z.string().uuid(),
+    toAccountId: z.string().uuid(),
+    amount: z.number().positive('Amount must be positive'),
+    description: z.string().optional(),
+  })
+  .refine((d) => d.fromAccountId !== d.toAccountId, {
+    message: 'Source and destination must differ',
+    path: ['toAccountId'],
+  })
 
 // Account Transaction schemas
 export const accountTransactionSchema = z.object({
@@ -133,3 +151,5 @@ export type PlaidAccountInput = z.infer<typeof plaidAccountSchema>
 export type UpdateAccountInput = z.infer<typeof updateAccountSchema>
 export type AccountTransactionInput = z.infer<typeof accountTransactionSchema>
 export type UpdateAccountTransactionInput = z.infer<typeof updateAccountTransactionSchema>
+export type RoundupSettingsInput = z.infer<typeof roundupSettingsSchema>
+export type AccountTransferInput = z.infer<typeof accountTransferSchema>


### PR DESCRIPTION
Adds the ability to choose an account to round up transactions to. This helps with banks like Chime that offer the service into savings accounts. 

Adds a transfers option that enables the user to create transfers between accounts. 
